### PR TITLE
Perf Boost

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = (...c) => (...a) => {
-  let i = c.length;
-  while (i--) a = [c[i] ? c[i](...a) : a];
-  return a[0];
+  let i = c.length - 1;
+  a = c[i](...a);
+  while (i--) a = c[i](a);
+  return a;
 };

--- a/test.js
+++ b/test.js
@@ -14,19 +14,6 @@ test('should compose functions', () => {
   expect(testFunction(2)).toBe(16);
 });
 
-test('should filter falsy values', () => {
-  const testFunction = compose(
-    sqr,
-    false,
-    undefined,
-    0,
-    null,
-    add2
-  );
-
-  expect(testFunction(2)).toBe(16);
-});
-
 test("should error when a function isn't passed", () => {
   const testFunction = compose(
     sqr,


### PR DESCRIPTION
all that array business killed perf. This adds a few bytes but is just as fast as before the last PR. I also removed support for passing anything but a function. 