### PR TITLE
Overhaul Types

### DIFF
--- a/compose-tiny.d.ts
+++ b/compose-tiny.d.ts
@@ -1,7 +1,92 @@
 declare module 'compose-tiny' {
-  type Step = (arg: any) => any
-  type Compose = (...functions: Step[]) => (arg: any) => any;
+  function Compose<T1>(fn0: (...args: any[]) => T1): (...arg: any[]) => T1;
 
-  const compose: Compose;
-  export = compose;
+  function Compose<T1, T2>(
+    fn1: (a: T1) => T2,
+    fn0: (...args: any[]) => T1
+  ): (...arg: any[]) => T2;
+
+  function Compose<T1, T2, T3>(
+    fn2: (a: T2) => T3,
+    fn1: (a: T1) => T2,
+    fn0: (...args: any[]) => T1
+  ): (...arg: any[]) => T3;
+
+  function Compose<T1, T2, T3, T4>(
+    fn3: (a: T3) => T4,
+    fn2: (a: T2) => T3,
+    fn1: (a: T1) => T2,
+    fn0: (...args: any[]) => T1
+  ): (...arg: any[]) => T4;
+
+  function Compose<T1, T2, T3, T4, T5>(
+    fn4: (a: T4) => T5,
+    fn3: (a: T3) => T4,
+    fn2: (a: T2) => T3,
+    fn1: (a: T1) => T2,
+    fn0: (...args: any[]) => T1
+  ): (...arg: any[]) => T5;
+
+  function Compose<T1, T2, T3, T4, T5, T6>(
+    fn5: (a: T5) => T6,
+    fn4: (a: T4) => T5,
+    fn3: (a: T3) => T4,
+    fn2: (a: T2) => T3,
+    fn1: (a: T1) => T2,
+    fn0: (...args: any[]) => T1
+  ): (...arg: any[]) => T6;
+
+  function Compose<T1, T2, T3, T4, T5, T6, T7>(
+    fn6: (a: T6) => T7,
+    fn5: (a: T5) => T6,
+    fn4: (a: T4) => T5,
+    fn3: (a: T3) => T4,
+    fn2: (a: T2) => T3,
+    fn1: (a: T1) => T2,
+    fn0: (...args: any[]) => T1
+  ): (...arg: any[]) => T7;
+
+  function Compose<T1, T2, T3, T4, T5, T6, T7, T8>(
+    fn7: (a: T7) => T8,
+    fn6: (a: T6) => T7,
+    fn5: (a: T5) => T6,
+    fn4: (a: T4) => T5,
+    fn3: (a: T3) => T4,
+    fn2: (a: T2) => T3,
+    fn1: (a: T1) => T2,
+    fn0: (...args: any[]) => T1
+  ): (...arg: any[]) => T8;
+
+  function Compose<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+    fn8: (a: T8) => T9,
+    fn7: (a: T7) => T8,
+    fn6: (a: T6) => T7,
+    fn5: (a: T5) => T6,
+    fn4: (a: T4) => T5,
+    fn3: (a: T3) => T4,
+    fn2: (a: T2) => T3,
+    fn1: (a: T1) => T2,
+    fn0: (...args: any[]) => T1
+  ): (...arg: any[]) => T9;
+
+  function Compose<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+    fn8: (a: T9) => T10,
+    fn7: (a: T7) => T8,
+    fn6: (a: T6) => T7,
+    fn5: (a: T5) => T6,
+    fn4: (a: T4) => T5,
+    fn3: (a: T3) => T4,
+    fn2: (a: T2) => T3,
+    fn1: (a: T1) => T2,
+    fn0: (...args: any[]) => T1
+  ): (...arg: any[]) => T10;
+
+  type Step = (arg: any) => any;
+  type FirstStep = (...arg: any[]) => any;
+
+  function Compose(
+    ...functions: Array<Step | FirstStep>
+  ): (...arg: any[]) => any;
+
+  export = Compose;
 }

--- a/compose-tiny.d.ts
+++ b/compose-tiny.d.ts
@@ -81,11 +81,24 @@ declare module 'compose-tiny' {
     fn0: (...args: any[]) => T1
   ): (...arg: any[]) => T10;
 
+  function Compose<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+    fn9: (a: T10) => T11,
+    fn8: (a: T9) => T10,
+    fn7: (a: T7) => T8,
+    fn6: (a: T6) => T7,
+    fn5: (a: T5) => T6,
+    fn4: (a: T4) => T5,
+    fn3: (a: T3) => T4,
+    fn2: (a: T2) => T3,
+    fn1: (a: T1) => T2,
+    fn0: (...args: any[]) => T1
+  ): (...arg: any[]) => T11;
+
   type Step = (arg: any) => any;
   type FirstStep = (...arg: any[]) => any;
 
   function Compose(
-    ...functions: Array<Step | FirstStep>
+    ...functions: Step[]
   ): (...arg: any[]) => any;
 
   export = Compose;


### PR DESCRIPTION
Up to 10 functions is typed explicitly. Past that still not too good.

The following will error when it shouldn't:

```ts
const add = (x: number, y: number) => x + y;
const add1 = (x: number) => add(x, 1);
const sqr = (x: number) => x * x;
const print = (x: number) => `Your number is ${x}.`;

// compose(sqr, add1)
const num = compose(
  print,
  add1,
  sqr,
  add1,
  add1,
  add1,
  add1,
  add1,
  add1,
  add1,
  sqr,
  add // TS ERROR: No way to do something like function(....rest, first)
);
```

If I do the following then no errors are produced for and of the other overloaded ones. Since people are likely to use < 10 functions I thought this was better. (PRs welcome!)

```ts
  type Step = (arg: any) => any;
  type FirstStep = (...arg: any[]) => any;

  function Compose(
    ...functions: Array<Step | FirstStep>
  ): (...arg: any[]) => any;
```

closes #18 